### PR TITLE
guild-fix+venv

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -364,7 +364,7 @@ async def guild(ctx):
       newUser = IdleUser(id, username)
       # record user avatar as picture
       author = ctx.message.author
-      avatarAsset = author.avatar_url_as(format = "png")
+      avatarAsset = author.avatar.replace(format = "png")
       userpic = USER_PICS_PATH + str(id) + '.png'
       await avatarAsset.save(userpic)
       newUser.setPic(userpic)

--- a/setup-Unix_MacOS-computer.sh
+++ b/setup-Unix_MacOS-computer.sh
@@ -1,0 +1,5 @@
+python -m venv .venv
+source .venv/bin/activate
+echo 'current python path: '
+echo $(.venv/bin/python)
+python -m pip install -r dependencies.txt

--- a/setup-windows-computer.ps1
+++ b/setup-windows-computer.ps1
@@ -1,0 +1,3 @@
+python -m venv .venv
+.venv\Scripts\activate
+python -m pip install -r dependencies.txt


### PR DESCRIPTION
# What changed:
This is to resolve #3 
The issue was that `message.author` previously had a bunch of accessors for the discord `Member` properties which were removed in discord.py 2.0 apparently. so `message.author.avatar_url_as` was replaced by `message.author.avatar.replace`. 

Also adding a some scripts to add a python virtual environment around the bot runtime. Useful when you have multiple python applications on the computer. Use the appropriate script.